### PR TITLE
Feat: kakaoSocialLogin

### DIFF
--- a/src/main/java/com/example/nuggetbe/config/CustomUserDetailService.java
+++ b/src/main/java/com/example/nuggetbe/config/CustomUserDetailService.java
@@ -1,0 +1,81 @@
+package com.example.nuggetbe.config;
+
+import com.example.nuggetbe.entity.Member;
+import com.example.nuggetbe.repository.MemberRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collection;
+import java.util.Collections;
+
+@Service
+public class CustomUserDetailService implements UserDetailsService {
+
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Long id = Long.parseLong(username);
+        Member member = memberRepository.findById(id).orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+
+        return new CustomUserDetails(member);
+    }
+    public class CustomUserDetails implements UserDetails {
+
+        private Member member;
+
+        public CustomUserDetails(Member member) {
+            this.member = member;
+        }
+
+        @Override
+        public String getUsername() {
+            return member.getId().toString();
+        }
+
+        @Override
+        public Collection<? extends GrantedAuthority> getAuthorities() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public String getPassword() {
+            return member.getPassword();
+        }
+
+        @Override
+        public boolean isAccountNonExpired() {
+            // 계정이 만료되지 않았는지
+            return true;
+        }
+
+        @Override
+        public boolean isAccountNonLocked() {
+            // 계정이 잠겨있지 않은지
+            return true;
+        }
+
+        @Override
+        public boolean isCredentialsNonExpired() {
+            // 자격 증명이 만료되지 않았는지
+            return true;
+        }
+
+        @Override
+        public boolean isEnabled() {
+            // 계정이 활성화되어 있는지
+            return true;
+        }
+
+    }
+}
+
+

--- a/src/main/java/com/example/nuggetbe/config/SecurityConfig.java
+++ b/src/main/java/com/example/nuggetbe/config/SecurityConfig.java
@@ -5,19 +5,23 @@ import com.example.nuggetbe.config.jwt.JwtAuthenticationEntryPoint;
 import com.example.nuggetbe.config.jwt.JwtSecurityConfig;
 import com.example.nuggetbe.config.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+
 
 @RequiredArgsConstructor
 @EnableWebSecurity
@@ -27,11 +31,23 @@ public class SecurityConfig{
     private final JwtTokenProvider tokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    @Autowired
+    private UserDetailsService userDetailsService;
+
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
+
+    @Bean
+    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+        AuthenticationManagerBuilder builder = http.getSharedObject(AuthenticationManagerBuilder.class);
+        builder.userDetailsService(userDetailsService).passwordEncoder(passwordEncoder());
+        return builder.build();
+    }
+
+
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/com/example/nuggetbe/config/jwt/JwtFilter.java
+++ b/src/main/java/com/example/nuggetbe/config/jwt/JwtFilter.java
@@ -26,8 +26,10 @@ public class JwtFilter extends GenericFilterBean {
         HttpServletRequest httpServletRequest = (HttpServletRequest) request;
         String jwt = resolveToken(httpServletRequest);
         String requestURI = httpServletRequest.getRequestURI();
+        System.out.println("requestURI = " + requestURI);
 
         if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+            System.out.println("jwt = " + jwt);
             Authentication authentication = tokenProvider.getAuthentication(jwt);
             SecurityContextHolder.getContext().setAuthentication(authentication);
             log.debug("Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}", authentication.getName(), requestURI);

--- a/src/main/java/com/example/nuggetbe/controller/MemberController.java
+++ b/src/main/java/com/example/nuggetbe/controller/MemberController.java
@@ -2,17 +2,14 @@ package com.example.nuggetbe.controller;
 
 import com.example.nuggetbe.dto.request.KakaoSignUpOAuthDto;
 import com.example.nuggetbe.dto.request.LoginDto;
-import com.example.nuggetbe.dto.response.BaseException;
-import com.example.nuggetbe.dto.response.BaseResponse;
-import com.example.nuggetbe.dto.response.BaseResponseStatus;
-import com.example.nuggetbe.dto.response.LoginRes;
+import com.example.nuggetbe.dto.request.SignUpDto;
+import com.example.nuggetbe.dto.response.*;
 import com.example.nuggetbe.entity.KakaoOAuthToken;
 import com.example.nuggetbe.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,27 +22,27 @@ public class MemberController {
     public BaseResponse<?> kakaoCallback(String code) {
         try {
             //code 이용 하여 oAuthAccessToken 얻어옴
-            KakaoOAuthToken kaKaoOAuthToken = memberService.getKakaoToken(code);
-            //oAuthAccessToken 으로 nickname 가져옴
-            String nickname = memberService.getOAuthInfo(kaKaoOAuthToken);
-            // 해당 nickname 으로 된 계정이 있는지 확인
-            Boolean notDuplicate = memberService.checkEmail(nickname);
-            // 없다면 회원가입 후 로그인
-            if (notDuplicate.equals(true)) {
-                KakaoSignUpOAuthDto signUpOAuthDto = new KakaoSignUpOAuthDto();
-                signUpOAuthDto.setName(nickname);
-                signUpOAuthDto.setEmail(nickname);
-                memberService.signUpOAUth(signUpOAuthDto);
-                LoginDto loginDto = new LoginDto();
-                loginDto.setEmail(nickname);
-                loginDto.setPassword("12345");
-                LoginRes loginRes = memberService.login(loginDto);
-                return new BaseResponse<>(BaseResponseStatus.SUCCESS, loginRes);
-            }
-            // 있다면 로그인
-            LoginDto loginDto = new LoginDto();
-            loginDto.setEmail(nickname);
-            loginDto.setPassword("12345");
+            CallbackResponse result = memberService.getKakaoToken(code);
+
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS, result);
+        } catch (BaseException e) {
+            return new BaseResponse<>(e.getStatus());
+        }
+    }
+
+    @PostMapping("/signUp")
+    public BaseResponse<?> signUp(@RequestBody @Valid SignUpDto signUpDto) {
+        try {
+            memberService.signUp(signUpDto);
+            return new BaseResponse<>(BaseResponseStatus.SUCCESS, "회원가입 성공");
+        } catch (BaseException e) {
+            return new BaseResponse(e.getStatus());
+        }
+    }
+
+    @PostMapping("/login")
+    public BaseResponse<?> login(@RequestBody LoginDto loginDto) {
+        try {
             LoginRes loginRes = memberService.login(loginDto);
             return new BaseResponse<>(BaseResponseStatus.SUCCESS, loginRes);
         } catch (BaseException e) {

--- a/src/main/java/com/example/nuggetbe/dto/request/LoginDto.java
+++ b/src/main/java/com/example/nuggetbe/dto/request/LoginDto.java
@@ -1,5 +1,6 @@
 package com.example.nuggetbe.dto.request;
 
+import com.example.nuggetbe.entity.KakaoOAuthToken;
 import lombok.*;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16,12 +17,7 @@ public class LoginDto {
 
     @JsonProperty
     @NotNull
-    private String email;
-
-
-    @JsonProperty
-    @NotNull
-    private String password;
+    private Long id;
 
 
 }

--- a/src/main/java/com/example/nuggetbe/dto/request/SignUpDto.java
+++ b/src/main/java/com/example/nuggetbe/dto/request/SignUpDto.java
@@ -1,0 +1,36 @@
+package com.example.nuggetbe.dto.request;
+
+import com.example.nuggetbe.entity.KakaoOAuthToken;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.antlr.v4.runtime.misc.NotNull;
+@Getter
+@Setter
+@NoArgsConstructor
+public class SignUpDto {
+
+    @JsonProperty
+    @NotNull
+    private Long id;
+
+    @JsonProperty
+    @NotNull
+    @Size(min =1, max = 50, message = "이름은 1글자 이상 50글자 이하여야 합니다.")
+    private String name;
+
+    @JsonProperty
+    @NotNull
+    private String address;
+
+    @JsonProperty
+    @NotNull
+    private String phoneNumber;
+
+    @JsonProperty
+    @NotNull
+    @Size(min = 3 , max = 100, message = "이메일은 3글자 이상 100글자 이하여야 합니다.")
+    private String email;
+}

--- a/src/main/java/com/example/nuggetbe/dto/response/BaseResponseStatus.java
+++ b/src/main/java/com/example/nuggetbe/dto/response/BaseResponseStatus.java
@@ -26,7 +26,8 @@ public enum BaseResponseStatus {
 
     WRONG_PASSWORD(false, 3002, "비밀번호가 틀렸습니다."),
     GET_OAUTH_TOKEN_FAILED(false, 3003, "oAuth 토큰 요청 실패"),
-    GET_OAUTH_INFO_FAILED(false, 3004, "oAuth Info 요청 실패");
+    GET_OAUTH_INFO_FAILED(false, 3004, "oAuth Info 요청 실패"),
+    NO_SUCH_MEMBER(false,3005 ,"No Such Member" );
 
 
 

--- a/src/main/java/com/example/nuggetbe/dto/response/CallbackResponse.java
+++ b/src/main/java/com/example/nuggetbe/dto/response/CallbackResponse.java
@@ -1,0 +1,14 @@
+package com.example.nuggetbe.dto.response;
+
+import com.example.nuggetbe.entity.KakaoOAuthToken;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class CallbackResponse {
+    private Long id;
+    private Boolean isSignedUp;
+}

--- a/src/main/java/com/example/nuggetbe/entity/Member.java
+++ b/src/main/java/com/example/nuggetbe/entity/Member.java
@@ -28,6 +28,9 @@ public class Member{
     private Long id;
 
     @Column(nullable = false)
+    private Boolean isSignedUp = false;
+
+    @Column(nullable = false)
     private String password;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/nuggetbe/repository/MemberRepository.java
+++ b/src/main/java/com/example/nuggetbe/repository/MemberRepository.java
@@ -8,5 +8,6 @@ import org.springframework.stereotype.Repository;
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Member findByEmail(String email);
+
 }
 


### PR DESCRIPTION
Feat: kakaoSocialLogin

로그인 로직 간단 설명

1. 카카오톡 소셜로그인을 하면 해당 계정 정보로 멤버 엔티티 객체 하나 생성 후 멤버 id와 회원가입 여부 return
>> 왜 email이나 name이 아니냐면 카카오톡에서는 nickname만 우리에게 전달해주는데 nickname은 사람마다 중복 가능해서 pk가 될 수 없음.
즉, nickname으로는 해당 멤버에 관한 정보를 db에서 찾아올 수 없기 때문에.

2-1. 만약 회원가입 여부가 false면, 
signUp api 호출해서 사용자 정보 + 멤버 id를 response로 받아 생성했던 멤버 데이터에 추가 저장

2-2. 만약 회원가입 여부가 true면,
login api 호출해서 멤버 id를 response로 넘긴다면 jwt 토큰이 생성돼 프론트에게 넘어가도록
혹시 몰라서 이메일까지 같이 넘겼는데(id는 이미 프론트가 갖고 있는 정보이므로), 이메일 대신 사용자 이름이나 그 외 사용자 프로필 정보가 필요하다면 로직 수정 예정